### PR TITLE
Use kernel.org mirror, as Argonne is no longer accessible.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ install() {
   rm -rf $DIR
 }
 
-install http://mirror.anl.gov/pub/ubuntu/pool/universe/r/runit/runit_2.0.0-1ubuntu4_amd64.deb
+install http://mirrors.kernel.org/ubuntu/pool/universe/r/runit/runit_2.1.1-6.2ubuntu3_amd64.deb
 
 mkdir -p .profile.d
 cat > .profile.d/runit.sh <<EOF


### PR DESCRIPTION
This fixes issue #6.