### PR TITLE
Fix bin/runsvdir-populate-service-dir to support comments in Procfile

### DIFF
--- a/bin/runsvdir-populate-service-dir
+++ b/bin/runsvdir-populate-service-dir
@@ -18,8 +18,12 @@ end
 
 File.open(PROCFILE_PATH) do |f|
   while line = f.gets
-    line.chomp!
-    ps, command = line.split(/:\s+/, 2)
+    if line !~ /^([A-Za-z0-9_-]+):\s*(.+)$/
+      next
+    end
+
+    ps = $1
+    command = $2
 
     write(ps, "run", <<EOF
 #!/bin/sh


### PR DESCRIPTION
`bin/runsvdir-populate-service-dir` wrongfully tries to process commented out (or blank) lines in dyno Procfiles, resulting in the fellowing error:

```
2015-04-09T13:31:18.318811+00:00 app[worker.1]: bin/runsvdir-populate-service-dir:9:in `join': no implicit conversion of nil into String (TypeError)
```

To reproduce:

```
~/src/sr/heroku-buildpack-runit[master]$ cat > Procfile.web
# automatically generated - do not modify directly

unicorn: script/unicorn 
^C
~/src/sr/heroku-buildpack-runit[master]$ bin/runsvdir-populate-service-dir ./tmp Procfile.web 
bin/runsvdir-populate-service-dir:9:in `join': no implicit conversion of nil into String (TypeError)
        from bin/runsvdir-populate-service-dir:9:in `write'
        from bin/runsvdir-populate-service-dir:24:in `block in <main>'
        from bin/runsvdir-populate-service-dir:19:in `open'
        from bin/runsvdir-populate-service-dir:19:in `<main>'
```

I have simply copied the regexp used by Foreman from here to fix the issue:

https://github.com/ddollar/foreman/blob/master/lib/foreman/procfile.rb#L86

@dpiddy Thanks a lot for releasing this — super helpful.